### PR TITLE
📦 Refactor: Separate Device Role Logic from NetworkManager

### DIFF
--- a/src/DeviceManager.cpp
+++ b/src/DeviceManager.cpp
@@ -1,4 +1,5 @@
 #include "DeviceManager.h"
+#include "NetworkManager.h"
 
 // Global DeviceManager instance
 DeviceManager device;
@@ -7,26 +8,64 @@ void DeviceManager::begin() {
     Serial.println("[DeviceManager] Initialized.");
 }
 
-void DeviceManager::assumeHostRole() {
-    host = true;
-    playerId = 0;
-    Serial.println("[DeviceManager] Host role assumed. Player ID set to 0.");
-}
-
-void DeviceManager::assumePlayerRole(uint8_t id) {
-    host = false;
-    playerId = id;
-    Serial.printf("[DeviceManager] Player role assumed. Player ID set to %u.\n", id);
-}
-
-bool DeviceManager::isHost() const {
+/* bool DeviceManager::isHost() const {
     return host;
 }
+ */
 
-uint8_t DeviceManager::getPlayerId() const {
-    return playerId;
+// Promote device to Host role; assign Player ID 0 and add broadcast peer
+void DeviceManager::becomeHost() {
+    Serial.println("\nBecoming HOST");
+    role = ROLE_HOST;
+    myPlayerID = 0; // Convention: host is always Player 0
+
+    esp_now_peer_info_t peerInfo = {};
+    memcpy(peerInfo.peer_addr, broadcastAddress, 6);
+    peerInfo.channel = 0;
+    peerInfo.encrypt = false;
+
+    if (esp_now_add_peer(&peerInfo) != ESP_OK) {
+        Serial.println("Failed to add broadcast peer");
+    }
 }
 
-void DeviceManager::setIsHost(bool value) {
-    host = value;
+// Promote device to Client role; assign Player ID 1 (static for now)
+void DeviceManager::becomeClient() {
+    Serial.println("Becoming CLIENT");
+    role = ROLE_CLIENT;
+    myPlayerID = 1;
+
+    // Add host as peer if MAC known
+    if (network.hostMac[0] != 0) {
+        esp_now_peer_info_t peerInfo = {};
+        memcpy(peerInfo.peer_addr, network.hostMac, 6);
+        peerInfo.channel = 0;
+        peerInfo.encrypt = false;
+
+        if (!esp_now_is_peer_exist(network.hostMac)) {
+            esp_err_t res = esp_now_add_peer(&peerInfo);
+            Serial.printf("[Network] Client added host peer (res=%d)\n", res);
+        }
+    } else {
+        Serial.println("[Network] Warning: hostMac not set when becoming client");
+    }
+}
+
+// Return current device role
+DeviceRole DeviceManager::getRole() const {
+    return role;
+}
+
+// Return current player ID
+uint8_t DeviceManager::getPlayerID() const {
+    return myPlayerID;
+}
+
+const char* DeviceManager::roleToString(DeviceRole role) {
+    switch (role) {
+        case ROLE_HOST: return "🧠 Host";
+        case ROLE_CLIENT: return "🎮 Client";
+        case ROLE_UNDEFINED: return "❓ Undefined";
+        default: return "🚫 Unknown";
+    }
 }

--- a/src/DeviceManager.h
+++ b/src/DeviceManager.h
@@ -3,27 +3,49 @@
 
 #include <Arduino.h>
 
+// =================================================================================
+//
+// ENUM DEFINITIONS
+//
+// =================================================================================
+
+// Device roles in the networked game.
+enum DeviceRole {
+    ROLE_UNDEFINED, // Role not yet determined
+    ROLE_HOST,      // Acts as Host
+    ROLE_CLIENT     // Acts as Client
+};
+
+// =================================================================================
+//
+// DEVICE MANAGER CLASS
+//
+// =================================================================================
+
 class DeviceManager {
 public:
-    // Initialize device role state
-    void begin();
+    // DeviceManager handles all role-related identity for this device.
+    // This includes role, player ID, and host/client transitions.
 
-    // Assign this device as the host
-    void assumeHostRole();
-    // Assign this device as a player with a specific ID
-    void assumePlayerRole(uint8_t id);
+    void begin();                         // Initialize device state
 
-    // Returns true if this device is the host
-    bool isHost() const;
-    // Returns the assigned player ID
-    uint8_t getPlayerId() const;
+    void setAsHost();                     // Assign this device as host
+    void setPlayerID(uint8_t id);         // Assign this device a player ID
 
-    // Manually set host status (used during role transition)
-    void setIsHost(bool value);
+    bool isHost() const;                  // True if acting as host
+    uint8_t getPlayerID() const;          // Get assigned player ID
 
-private:
-    bool host = false;                // True if device is acting as host
-    uint8_t playerId = 0;             // Assigned player ID (range: 0–3)
+    DeviceRole getRole() const;           // Get current role
+    static const char* roleToString(DeviceRole role);
+
+    void becomeHost();                    // Host transition logic
+    void becomeClient();                  // Client transition logic
+
+    DeviceRole role = ROLE_UNDEFINED;       // Current device role
+    uint8_t myPlayerID = 0;
+
+    private:
+                   // Assigned player ID
     unsigned long lastUpdateTime = 0; // Last activity timestamp (reserved for future use)
 };
 

--- a/src/DisplayManager.cpp
+++ b/src/DisplayManager.cpp
@@ -242,7 +242,7 @@ void DisplayManager::drawLogo(int x, int y) {
 
 void DisplayManager::drawDeviceRole() {
     const char* roleText = "";
-    switch (network.getRole()) {
+    switch (device.getRole()) {
         case ROLE_HOST:
             roleText = "HOST";
             break;

--- a/src/NetworkManager.h
+++ b/src/NetworkManager.h
@@ -5,18 +5,8 @@
 #include <esp_now.h>
 #include <WiFi.h>
 
-// =================================================================================
-//
-// ENUM DEFINITIONS
-//
-// =================================================================================
-
-// Device roles in the networked game.
-enum DeviceRole {
-    ROLE_UNDEFINED, // Role not yet determined
-    ROLE_HOST,      // Acts as Host
-    ROLE_CLIENT     // Acts as Client
-};
+// Global broadcast address for ESP-NOW
+extern uint8_t broadcastAddress[6];
 
 // =================================================================================
 //
@@ -81,8 +71,6 @@ class NetworkManager {
 public:
     void begin();                           // Initialize networking and start discovery
     void updateRole();                      // Called regularly from loop()
-    DeviceRole getRole();                   // Returns current device role
-    uint8_t getPlayerID();                  // Returns assigned player ID
 
     void sendLifeUpdate(uint8_t life);     // Client requests life change
     void sendTurnChange();                  // Client requests turn change
@@ -94,9 +82,6 @@ public:
     uint8_t playerCount = 4;
     uint8_t currentTurn = 0;
     uint8_t lifeTotals[4] = {20, 20, 20, 20};
-    DeviceRole role = ROLE_UNDEFINED;       // Current device role
-
-    static const char* roleToString(DeviceRole role);
 
     void heartbeat();                       // Called regularly in loop()
     const uint8_t* getHostMAC() const;
@@ -112,18 +97,15 @@ public:
     void sendLifeChangeRequest(uint8_t playerId, uint8_t newLifeTotal);
     void sendPoisonChangeRequest(uint8_t playerId, uint8_t newPoison);
 
+    uint8_t hostMac[6] = {0};               // MAC address of detected Host
+
 private:
-    uint8_t myPlayerID = 0;                 // Assigned player ID
-
     void setupESPNow();                     // Initialize ESP-NOW
-    void becomeHost();                      // Set device as Host
-    void becomeClient();                    // Set device as Client
-
     bool hostDetected = false;              // Indicates if Host was detected during discovery
     unsigned long discoveryStartTime = 0;  // Discovery start time
-    uint8_t hostMac[6] = {0};               // MAC address of detected Host
 };
 
-extern NetworkManager network;  // External declaration
+// Global instance of the device manager
+extern NetworkManager network;
 
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,7 @@ void setup() {
 
   network.markReady();  // Notify that network can apply incoming game state
   network.updateRole(); // Determine and assign device role (host/client)
-  Serial.printf("[Main] Role Assigned: %s\n", NetworkManager::roleToString(network.getRole()));
+  Serial.printf("[Main] Role Assigned: %s\n", DeviceManager::roleToString(device.getRole()));
 
   // --- Initialize Input ---
   input->begin();
@@ -40,12 +40,12 @@ void setup() {
   Serial.println("[Main] Game setup environment prepared");
 
   network.sendGameState();  // If host, broadcast game setup to all devices
-  if (network.getRole() == ROLE_CLIENT) {
+  if (device.getRole() == ROLE_CLIENT) {
     Serial.println("[Main] Setup received from host");
   }
 
   // --- Initialize Game State ---
-  gameState.begin(device.getPlayerId(), gameSetup.getStartingLife());
+  gameState.begin(device.getPlayerID(), gameSetup.getStartingLife());
 
   // --- Initial Render of All Players ---
   for (int id = 0; id < gameSetup.getPlayerCount(); ++id) {

--- a/src/testing/SimulationInputManager.cpp
+++ b/src/testing/SimulationInputManager.cpp
@@ -1,6 +1,7 @@
 #include "GameState.h"
 #include "testing/SimulationInputManager.h"
-#include "Config.h"
+#include "DeviceManager.h"
+#include "NetworkManager.h"
 
 // Initializes the simulation input manager.
 // Outputs a startup message to Serial for confirmation.
@@ -36,12 +37,12 @@ void SimulationInputManager::update() {
 
             gameState.adjustPoison(selectedPlayer, delta);
 
-            if (network.getRole() == ROLE_HOST &&
+            if (device.getRole() == ROLE_HOST &&
                 gameState.getPlayerState(selectedPlayer).poison != oldPoison) {
                 network.sendGameState();
             }
 
-            if (network.getRole() == ROLE_CLIENT) {
+            if (device.getRole() == ROLE_CLIENT) {
                 uint8_t newPoison = gameState.getPlayerState(selectedPlayer).poison;
                 network.sendPoisonChangeRequest(selectedPlayer, newPoison);
             }
@@ -56,12 +57,12 @@ void SimulationInputManager::update() {
             int oldLife = gameState.getLife(selectedPlayer);
             gameState.adjustLife(selectedPlayer, delta);
 
-            if (network.getRole() == ROLE_HOST &&
+            if (device.getRole() == ROLE_HOST &&
                 gameState.lifeChanged(selectedPlayer, oldLife)) {
                 network.sendGameState();
             }
 
-            if (network.getRole() == ROLE_CLIENT) {
+            if (device.getRole() == ROLE_CLIENT) {
                 uint8_t newLife = gameState.getLife(selectedPlayer);
                 network.sendLifeChangeRequest(selectedPlayer, newLife);
             }


### PR DESCRIPTION
🔧 Summary
This PR moves all device identity and role management logic (e.g. host/client state, player ID) out of NetworkManager and into DeviceManager, aligning with the architectural goal of separating concerns:

DeviceManager now owns:

Host/client assignment via becomeHost() and becomeClient()

Player ID assignment

Device role state via DeviceRole enum

Role-accessors like getRole() and getPlayerID()

NetworkManager is now focused purely on:

ESP-NOW initialization

Message send/receive and broadcasting

Host announcement and game state transmission

✅ What Was Changed
🔁 Moved DeviceRole enum, getRole, getPlayerID, and role flags into DeviceManager

🔧 Refactored becomeHost() and becomeClient() to live inside DeviceManager

🧹 Cleaned up redundant/duplicated methods and variables across both modules

🛠️ Fixed linker error from broadcastAddress being multiply defined by making it extern in the header and defined only in NetworkManager.cpp

🎯 Why This Matters
Clarifies architectural boundaries between networking and device state

Makes future debugging and expansion (e.g. role reassignment, auto-recovery) more maintainable

Avoids logic duplication between modules

🧪 How to Test
Devices correctly assign host/client roles on startup

Host announcements are received and reflected in device state

Game state sync still functions as expected via NetworkManager